### PR TITLE
chore: Update gradle wrapper to version 8.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ This project uses a Gradle Wrapper, so you don't need to install Gradle on your 
 ### Wrapper Maintenance
 If you need to update the Gradle version used by the project, you can run the following command. This requires a local Gradle installation.
 ```bash
-# Example: Update to Gradle 8.8
-gradle wrapper --gradle-version 8.8
+# Example: Update to Gradle 8.14
+gradle wrapper --gradle-version 8.14
 ```
 After running the command, be sure to commit the changed wrapper files to version control.
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Updates the Gradle wrapper version from 8.5 to 8.14 to match the user's development environment.

Also updates the example in the README.md to reflect the new version.