### PR TITLE
fix: Update Lombok version to fix Java 24 incompatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,9 @@ subprojects {
 
     dependencies {
         // Common dependencies for all modules
-        compileOnly 'org.projectlombok:lombok'
-        annotationProcessor 'org.projectlombok:lombok'
+        // Force Lombok version compatible with Java 24
+        compileOnly 'org.projectlombok:lombok:1.18.38'
+        annotationProcessor 'org.projectlombok:lombok:1.18.38'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
     }
 


### PR DESCRIPTION
Updates the Lombok version to 1.18.38 across all subprojects.

This resolves a `java.lang.ExceptionInInitializerError` caused by an incompatibility between the previous Lombok version and the Java 24 compiler internals. The new version officially supports Java 24.