### PR TITLE
fix: Apply java-library plugin to enable 'api' scope

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ allprojects {
 }
 
 subprojects {
-    apply plugin: 'java'
     apply plugin: 'io.spring.dependency-management'
 
     java {

--- a/common-security/build.gradle
+++ b/common-security/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'java-library'
+}
+
 dependencies {
     // This module depends on common-core for any shared utilities or base entities
     implementation project(':common-core')

--- a/common-web/build.gradle
+++ b/common-web/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'java-library'
+}
+
 dependencies {
     // This module may depend on common-core for shared utilities
     implementation project(':common-core')


### PR DESCRIPTION
- Removes the global `apply plugin: 'java'` from the root build script.
- Applies the `java-library` plugin to the `common-security` and `common-web` modules.

This is necessary to enable the `api` dependency configuration, which was used in a previous commit to expose transitive dependencies to downstream modules. Without the `java-library` plugin, the `api` configuration is not recognized by Gradle, causing a build failure.