### PR TITLE
fix: Resolve all build issues and update documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.3.0' apply false
-    id 'io.spring.dependency-management' version '1.1.4' apply false
+    id 'org.springframework.boot' version '3.5.5' apply false
+    id 'io.spring.dependency-management' version '1.1.6' apply false
 }
 
 allprojects {
@@ -11,32 +11,34 @@ allprojects {
     repositories {
         mavenCentral()
     }
+
+    // Apply configurations only to projects that have the Java plugin
+    plugins.withType(JavaPlugin) {
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(24)
+            }
+        }
+
+        dependencies {
+            // Force Lombok version compatible with Java 24
+            compileOnly 'org.projectlombok:lombok:1.18.38'
+            annotationProcessor 'org.projectlombok:lombok:1.18.38'
+            testImplementation 'org.springframework.boot:spring-boot-starter-test'
+        }
+
+        tasks.named('test') {
+            useJUnitPlatform()
+        }
+    }
 }
 
 subprojects {
     apply plugin: 'io.spring.dependency-management'
 
-    java {
-        toolchain {
-            languageVersion = JavaLanguageVersion.of(24)
-        }
-    }
-
-    dependencies {
-        // Common dependencies for all modules
-        // Force Lombok version compatible with Java 24
-        compileOnly 'org.projectlombok:lombok:1.18.38'
-        annotationProcessor 'org.projectlombok:lombok:1.18.38'
-        testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    }
-
     dependencyManagement {
         imports {
             mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
         }
-    }
-
-    tasks.named('test') {
-        useJUnitPlatform()
     }
 }

--- a/cmms10/src/test/java/com/platform/cmms10/workpermit/controller/WorkPermitControllerTest.java
+++ b/cmms10/src/test/java/com/platform/cmms10/workpermit/controller/WorkPermitControllerTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -45,9 +45,9 @@ class WorkPermitControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean private WorkPermitService workPermitService;
-    @MockBean private CodeService codeService;
-    @MockBean private DeptService deptService;
+    @MockitoBean private WorkPermitService workPermitService;
+    @MockitoBean private CodeService codeService;
+    @MockitoBean private DeptService deptService;
 
     private WorkPermit workPermit;
     private List<Code> mockPermitTypes;

--- a/common-core/build.gradle
+++ b/common-core/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'java-library'
+}

--- a/common-web/build.gradle
+++ b/common-web/build.gradle
@@ -12,6 +12,9 @@ dependencies {
 
     // For Thymeleaf layout dialect
     implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
+
+    // Add Spring Security integration for Thymeleaf
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 }
 
 // This is a library module, not a runnable application

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+}
+
 rootProject.name = 'platform-monorepo'
 
 include 'common-core'


### PR DESCRIPTION
This cumulative commit resolves a long series of build failures and completes the project setup.

Changes:
- Add Gradle Wrapper to the project for consistent builds.
- Update root `build.gradle` to use idiomatic configurations (`allprojects`, `plugins.withType`) for applying dependencies and settings to submodules.
- Update Spring Boot plugin to version 3.5.5 for Java 24 compatibility.
- Force Lombok version to 1.18.38 to fix incompatibility with Java 24.
- Add `thymeleaf-extras-springsecurity6` to resolve template processing errors.
- Apply `java-library` plugin to library modules and use `api` scope for shared dependencies.
- Create placeholder `common-core` module to satisfy project dependencies.
- Add Foojay toolchain resolver plugin to `settings.gradle` to enable auto-download of JDKs.
- Add a comprehensive `.gitignore` file.
- Update `README.md` with detailed instructions for building and running the project.